### PR TITLE
Msl option for flat modelica

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OM"
 uuid = "2f925a0b-2436-437b-858e-49aee461894b"
 authors = ["John Tinnerholm <john.tinnerholm@liu.se>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Absyn = "ce2f92e2-a952-11e9-0543-8b443f216f1d"

--- a/src/OM.jl
+++ b/src/OM.jl
@@ -233,8 +233,12 @@ end
 """
   Returns the flat Modelica representation as a String.
 """
-function generateFlatModelica(modelName::String, file::String)
-  toString(first(flattenFM(modelName, file)))
+function generateFlatModelica(modelName::String, file::String; MSL = true)
+  if MSL
+    toString(first(OMFrontend.flattenModelWithMSL(modelName, file)))
+  else
+    toString(first(flattenFM(modelName, file)))
+  end
 end
 
 """


### PR DESCRIPTION
This PR enables the user to enable MSL use when exporting flat Modelica