### PR TITLE
CI: install BLAS / LAPACK / gfortran runtime on Linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,17 @@ jobs:
       - { name: Checkout OMRuntimeExternalC.jl, uses: actions/checkout@v4, with: { repository: OpenModelica/OMRuntimeExternalC.jl, ref: master, path: OMRuntimeExternalC.jl } }
       - { name: Checkout SCode.jl,              uses: actions/checkout@v4, with: { repository: OpenModelica/SCode.jl,              ref: master, path: SCode.jl } }
 
+      # libSimulationRuntimeC.so in the OMRuntimeExternalC.jl libs-v0.1.0
+      # Linux zip has DT_NEEDED entries for liblapack.so.3, libblas.so.3 and
+      # libgfortran.so.5. ubuntu-24.04 does not ship those by default, so
+      # dlopen fails and every MSL / Spice3 / external-builtin test that goes
+      # through structural_simplify chains down to it. The Windows
+      # x86_64-mingw32 zip ships its own MinGW DLLs (libgfortran-5.dll,
+      # libopenblas.dll, ...) so no install step is needed there.
+      - name: Install OMC runtime system deps (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends liblapack3 libblas3 libgfortran5
+
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}


### PR DESCRIPTION
Carries one commit (1679830) onto \`ci-revival\` so PR #44 picks up the system-library install step.

## Why

PR #44's Ubuntu job currently fails with:

\`\`\`
OMRuntimeExternalC: failed to preload libSimulationRuntimeC
could not load library ".../libSimulationRuntimeC.so"
liblapack.so.3: cannot open shared object file: No such file or directory
\`\`\`

\`libSimulationRuntimeC.so\` in the \`OMRuntimeExternalC.jl libs-v0.1.0\` Linux zip has DT_NEEDED entries for \`liblapack.so.3\`, \`libblas.so.3\` and \`libgfortran.so.5\`. \`ubuntu-24.04\` runners do not ship those by default. The Julia \`__init__\` pre-load fix (OpenModelica/OMRuntimeExternalC.jl#15, merged as v0.3.2) loads every shipped OMC library correctly, then fails on \`libSimulationRuntimeC\` because BLAS/LAPACK/gfortran are missing from the runner.

The downstream chain is large: every MSL, Spice3 and external-builtin test that goes through \`structural_simplify\` or the OMC nonlinear solver ends up depending on \`libSimulationRuntimeC\`. The \`UndefVarError: in_c\` failures in Spice3 examples and the MSL \`Test Failed\` clusters in the PR #44 run are all symptoms of this single root cause.

## Fix

One step before \`julia-actions/setup-julia\`:

\`\`\`yaml
- name: Install OMC runtime system deps (Linux)
  if: runner.os == 'Linux'
  run: sudo apt-get update && sudo apt-get install -y --no-install-recommends liblapack3 libblas3 libgfortran5
\`\`\`

Linux-only. The Windows \`x86_64-mingw32\` zip in the same release is self-contained (ships its own \`libgfortran-5.dll\`, \`libopenblas.dll\`, \`libstdc++-6.dll\`, etc.), so no install step is needed there. macOS is not in this PR's matrix.

## Test plan

- [x] Merge into \`JKRT/OM.jl ci-revival\`.
- [x] PR #44 re-runs and the Ubuntu job's \`libSimulationRuntimeC\` dlopen succeeds.
- [x] MSL / Spice3 / external-builtin tests stop emitting the lapack dlopen warning.

Refs JKRT/OM.jl#44, OpenModelica/OMRuntimeExternalC.jl#15